### PR TITLE
fix: await checkConsentStatus in LGPD hook

### DIFF
--- a/src/hooks/useLGPDConsent.ts
+++ b/src/hooks/useLGPDConsent.ts
@@ -15,7 +15,7 @@ export const useLGPDConsent = () => {
   })
 
   useEffect(() => {
-    checkConsentStatus()
+    checkConsentStatus().catch(console.error)
   }, [])
 
   const checkConsentStatus = async () => {


### PR DESCRIPTION
## Summary
- avoid unhandled promise rejection in `useLGPDConsent`

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: missing packages and types)*

------
https://chatgpt.com/codex/tasks/task_e_68402a8163388325906630a1e8f73ef5