### PR TITLE
Clarify ip_blocks expiration rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -760,10 +760,12 @@ CREATE TABLE ip_blocks (
   ativo BOOLEAN DEFAULT TRUE,
   attempts INTEGER DEFAULT 1,
   country TEXT, city TEXT,                      -- Geolocalização
-  expires_at TIMESTAMP WITH TIME ZONE,          -- Bloqueio temporário vs permanente
+  expires_at TIMESTAMP WITH TIME ZONE,          -- NULL = bloqueio permanente
   unblocked_at TIMESTAMP WITH TIME ZONE         -- Histórico de desbloqueios
 );
 ```
+
+Em **`ip_blocks`**, quando `expires_at` está `NULL`, o bloqueio é considerado permanente. Para bloqueios temporários, defina uma data e hora de expiração.
 
 #### **📊 4. Dashboard de Segurança com Alertas em Tempo Real**
 


### PR DESCRIPTION
## Summary
- clarify that NULL `expires_at` means a permanent IP block

## Testing
- `npm run lint` *(fails: couldn't find eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_68402a8ad85883259ee5ca212b29d203